### PR TITLE
Fix game over when trying to move in opposite direction

### DIFF
--- a/src/direction.rs
+++ b/src/direction.rs
@@ -1,7 +1,7 @@
 use point;
 use rand::{Rand, Rng};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Direction {
     Up,
     Down,

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,10 +182,10 @@ fn main() {
             Ok(rustbox::Event::KeyEvent(key)) => {
                 match key {
                     Key::Esc   => { break; },
-                    Key::Up    => { snake.direction = direction::Direction::Down; },
-                    Key::Down  => { snake.direction = direction::Direction::Up; },
-                    Key::Left  => { snake.direction = direction::Direction::Left; },
-                    Key::Right => { snake.direction = direction::Direction::Right; },
+                    Key::Up    => if snake.direction != direction::Direction::Up { snake.direction = direction::Direction::Down; },
+                    Key::Down  => if snake.direction != direction::Direction::Down { snake.direction = direction::Direction::Up; },
+                    Key::Left  => if snake.direction != direction::Direction::Right { snake.direction = direction::Direction::Left; },
+                    Key::Right => if snake.direction != direction::Direction::Left { snake.direction = direction::Direction::Right; },
                     _ => { }
                 }
             },


### PR DESCRIPTION
For example, the snake is moving towards right. If user inputs <kbd>←</kbd> (left), the snake bites itself and game ends. I do not know if this is intended but this PR fixes it by ignoring opposite movement inputs.